### PR TITLE
Server Side Request Forgery vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -48,7 +48,7 @@ public class SSRFTask2 extends AssignmentEndpoint {
   protected AttackResult furBall(String url) {
     if (url.matches("http://ifconfig\\.pro")) {
       String html;
-      try (InputStream in = new URL(url).openStream()) {
+      try (InputStream in = new URL("https://example.com/" + String.valueOf(url).replaceAll("^\\w+://.*?/", "")).openStream()) {
         html =
             new String(in.readAllBytes(), StandardCharsets.UTF_8)
                 .replaceAll("\n", "<br>"); // Otherwise the \n gets escaped in the response


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Server Side Request Forgery** issue reported by **Checkmarx**.

## Issue description
Server-Side Request Forgery (SSRF) allows attackers to make unauthorized requests from a vulnerable server, potentially accessing internal systems, services, or data.
 
## Fix instructions
Validate or sanitize user-supplied URLs, ensuring that they are restricted to trusted domains. Implementing proper input validation and using whitelists for acceptable URLs can prevent SSRF attacks.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/3c7d5b89-3f1a-4571-bd0c-edf301a20e77/project/adfb6ecb-1012-455a-9926-69cb8b8bbf90/report/651ff62f-7e0e-4df9-80e2-caa76e6c7110/fix/d6c2b0bd-40fe-4607-a6e0-a39cacd1a679)