### PR TITLE
Server Side Request Forgery vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -48,7 +48,7 @@ public class SSRFTask2 extends AssignmentEndpoint {
   protected AttackResult furBall(String url) {
     if (url.matches("http://ifconfig\\.pro")) {
       String html;
-      try (InputStream in = new URL(url).openStream()) {
+      try (InputStream in = new URL("https://example.com/" + String.valueOf(url).replaceAll("^\\w+://.*?/", "")).openStream()) {
         html =
             new String(in.readAllBytes(), StandardCharsets.UTF_8)
                 .replaceAll("\n", "<br>"); // Otherwise the \n gets escaped in the response


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Server Side Request Forgery** issue reported by **Checkmarx**.
  
## Issue description
Server-Side Request Forgery (SSRF) allows attackers to make unauthorized requests from a vulnerable server, potentially accessing internal systems, services, or data.
 
## Fix instructions
Validate or sanitize user-supplied URLs, ensuring that they are restricted to trusted domains. Implementing proper input validation and using whitelists for acceptable URLs can prevent SSRF attacks.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/73a94759-8baf-4bce-bdef-4721beb61a01/project/de80b47e-379b-48ff-8f67-8f073cff2f96/report/5895e23d-9724-44d8-8ee8-0e1c875d32d6/fix/0b7db5e9-620c-4d09-b89f-7b7965d85116)