### PR TITLE
Path Traversal vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/MD5.java
+++ b/src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/MD5.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 
 /**
  * MD5 hash generator. More information about this class is available from <a target="_top" href=
@@ -46,11 +47,43 @@ public class MD5 {
     } else {
       for (String element : args) {
         try {
+          ensurePathIsRelative(element);
           System.out.println(MD5.getHashString(new File(element)) + " " + element);
         } catch (IOException x) {
           System.err.println(x.getMessage());
         }
       }
+    }
+  }
+
+  private static void ensurePathIsRelative(String path) {
+    ensurePathIsRelative(new File(path));
+  }
+
+
+  private static void ensurePathIsRelative(URI uri) {
+    ensurePathIsRelative(new File(uri));
+  }
+
+
+  private static void ensurePathIsRelative(File file) {
+    // Based on https://stackoverflow.com/questions/2375903/whats-the-best-way-to-defend-against-a-path-traversal-attack/34658355#34658355
+    String canonicalPath;
+    String absolutePath;
+  
+    if (file.isAbsolute()) {
+      throw new RuntimeException("Potential directory traversal attempt - absolute path not allowed");
+    }
+  
+    try {
+      canonicalPath = file.getCanonicalPath();
+      absolutePath = file.getAbsolutePath();
+    } catch (IOException e) {
+      throw new RuntimeException("Potential directory traversal attempt", e);
+    }
+  
+    if (!canonicalPath.startsWith(absolutePath) || !canonicalPath.equals(absolutePath)) {
+      throw new RuntimeException("Potential directory traversal attempt");
     }
   }
 


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Path Traversal** issue reported by **Checkmarx**.
  
## Issue description
Path Traversal AKA Directory Traversal occurs when a path coming from user input is not properly sanitized, allowing an attacker to navigate through directories beyond the intended scope. Attackers can exploit this to access sensitive files or execute arbitrary code.
 
## Fix instructions
Sanitize user-supplied paths, ensuring that they are restricted to a predefined directory structure.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/73a94759-8baf-4bce-bdef-4721beb61a01/project/de80b47e-379b-48ff-8f67-8f073cff2f96/report/5895e23d-9724-44d8-8ee8-0e1c875d32d6/fix/1098578e-4690-44d7-81ca-af14505a4f56)