### PR TITLE
Server Side Request Forgery vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -48,7 +48,7 @@ public class SSRFTask2 extends AssignmentEndpoint {
   protected AttackResult furBall(String url) {
     if (url.matches("http://ifconfig\\.pro")) {
       String html;
-      try (InputStream in = new URL(url).openStream()) {
+      try (InputStream in = new URL("https://example.com/" + String.valueOf(url).replaceAll("^\\w+://.*?/", "")).openStream()) {
         html =
             new String(in.readAllBytes(), StandardCharsets.UTF_8)
                 .replaceAll("\n", "<br>"); // Otherwise the \n gets escaped in the response


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Server Side Request Forgery** issue reported by **Checkmarx**.

## Issue description
Server-Side Request Forgery (SSRF) allows attackers to make unauthorized requests from a vulnerable server, potentially accessing internal systems, services, or data.
 
## Fix instructions
Validate or sanitize user-supplied URLs, ensuring that they are restricted to trusted domains. Implementing proper input validation and using whitelists for acceptable URLs can prevent SSRF attacks.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/bdb0b672-2beb-4c3c-b9d3-af9f68d18426/project/fd92502a-fcf9-453c-b432-579d5745e48f/report/2645a00d-cdf1-40b0-b551-d03b8cdd758c/fix/83998a8a-cfb8-4024-b073-488e3501b099)