### PR TITLE
Log Forging vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/MD5.java
+++ b/src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/MD5.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 
 /**
  * MD5 hash generator. More information about this class is available from <a target="_top" href=
@@ -46,11 +47,43 @@ public class MD5 {
     } else {
       for (String element : args) {
         try {
+          ensurePathIsRelative(element);
           System.out.println(MD5.getHashString(new File(element)) + " " + element);
         } catch (IOException x) {
           System.err.println(x.getMessage());
         }
       }
+    }
+  }
+
+  private static void ensurePathIsRelative(String path) {
+    ensurePathIsRelative(new File(path));
+  }
+
+
+  private static void ensurePathIsRelative(URI uri) {
+    ensurePathIsRelative(new File(uri));
+  }
+
+
+  private static void ensurePathIsRelative(File file) {
+    // Based on https://stackoverflow.com/questions/2375903/whats-the-best-way-to-defend-against-a-path-traversal-attack/34658355#34658355
+    String canonicalPath;
+    String absolutePath;
+  
+    if (file.isAbsolute()) {
+      throw new RuntimeException("Potential directory traversal attempt - absolute path not allowed");
+    }
+  
+    try {
+      canonicalPath = file.getCanonicalPath();
+      absolutePath = file.getAbsolutePath();
+    } catch (IOException e) {
+      throw new RuntimeException("Potential directory traversal attempt", e);
+    }
+  
+    if (!canonicalPath.startsWith(absolutePath) || !canonicalPath.equals(absolutePath)) {
+      throw new RuntimeException("Potential directory traversal attempt");
     }
   }
 

--- a/src/main/java/org/owasp/webgoat/webwolf/requests/LandingPage.java
+++ b/src/main/java/org/owasp/webgoat/webwolf/requests/LandingPage.java
@@ -45,7 +45,7 @@ public class LandingPage {
       })
   public Callable<ResponseEntity<?>> ok(HttpServletRequest request) {
     return () -> {
-      log.trace("Incoming request for: {}", request.getRequestURL());
+      log.trace("Incoming request for: {}", String.valueOf(request.getRequestURL()).replace("\n", "").replace("\r", ""));
       return ResponseEntity.ok().build();
     };
   }


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **Log Forging** issue reported by **Checkmarx**.

## Issue description
Log Forging allows attackers to manipulate log files by injecting malicious content. This can be used to obfuscate attack traces or forge log entries to conceal unauthorized activities.
 
## Fix instructions
Implement proper input sanitization to remove new lines for values going to the log.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/bdb0b672-2beb-4c3c-b9d3-af9f68d18426/project/fd92502a-fcf9-453c-b432-579d5745e48f/report/2645a00d-cdf1-40b0-b551-d03b8cdd758c/fix/7a8e73f8-9e9d-4804-80b7-c48accc8eeb0)