### PR TITLE
Server Side Request Forgery vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -48,7 +48,7 @@ public class SSRFTask2 extends AssignmentEndpoint {
   protected AttackResult furBall(String url) {
     if (url.matches("http://ifconfig\\.pro")) {
       String html;
-      try (InputStream in = new URL(url).openStream()) {
+      try (InputStream in = new URL("https://example.com/" + String.valueOf(url).replaceAll("^\\w+://.*?/", "")).openStream()) {
         html =
             new String(in.readAllBytes(), StandardCharsets.UTF_8)
                 .replaceAll("\n", "<br>"); // Otherwise the \n gets escaped in the response


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Server Side Request Forgery** issue reported by **Checkmarx**.

## Issue description
Server-Side Request Forgery (SSRF) allows attackers to make unauthorized requests from a vulnerable server, potentially accessing internal systems, services, or data.
 
## Fix instructions
Validate or sanitize user-supplied URLs, ensuring that they are restricted to trusted domains. Implementing proper input validation and using whitelists for acceptable URLs can prevent SSRF attacks.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/e13befe5-1156-412d-b8d7-4ac73aca8e8e/project/6f4cef65-4644-46f8-a067-b41d25711372/report/b50d99d2-90e2-4a13-8ff2-71251b01d3e7/fix/0d468945-8d2a-49ed-80bb-f360d73c95ba)